### PR TITLE
Renamed GetInvoicePDF to GetInvoicePDFAsync

### DIFF
--- a/QuickBooksSharp.Tests/DataServiceTests.cs
+++ b/QuickBooksSharp.Tests/DataServiceTests.cs
@@ -291,13 +291,13 @@ namespace QuickBooksSharp.Tests
         }
 
         [TestMethod]
-        public async Task GetInvoicePDF()
+        public async Task GetInvoicePDFAsync()
         {
             var response = await _service.QueryAsync<Invoice>("SELECT * FROM Invoice MAXRESULTS 1");
 
             Assert.IsTrue(response.Response.Entities.Length > 0);
 
-            var invoidePdfStream = await _service.GetInvoicePDF(response.Response.Entities[0].Id);
+            var invoidePdfStream = await _service.GetInvoicePDFAsync(response.Response.Entities[0].Id);
 
             Assert.IsNotNull(invoidePdfStream);
             Assert.IsNotNull(invoidePdfStream.Length > 0);

--- a/QuickBooksSharp/Services/DataService.cs
+++ b/QuickBooksSharp/Services/DataService.cs
@@ -129,14 +129,11 @@ namespace QuickBooksSharp
             };
         }
 
-        /// <summary>
-        /// Get an invoice as PDF
-        /// <para>This resource returns the specified object in the response body as an Adobe Portable Document Format (PDF) file. The resulting PDF file is formatted according to custom form styles in the company settings.</para>
-        /// <see href="https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/invoice#get-an-invoice-as-pdf">QBO Documentation</see>
-        /// </summary>
-        /// <param name="invoiceId">Unique identifier for this object</param>
-        /// <returns>This resource returns the specified object in the response body as an Adobe Portable Document Format (PDF) file. The resulting PDF file is formatted according to custom form styles in the company settings.</returns>
-        public async Task<Stream> GetInvoicePDF(string invoiceId)
+        [Obsolete("Use GetInvoicePDFAsync")]
+        public async Task<Stream> GetInvoicePDF(string invoiceId) => await GetInvoicePDFAsync(invoiceId);
+
+        /// <inheritdoc/>
+        public async Task<Stream> GetInvoicePDFAsync(string invoiceId)
         {
             var url = new Url(_serviceUrl).AppendPathSegment($"/invoice/{invoiceId}/pdf");
             var res = await _client.SendAsync(() =>

--- a/QuickBooksSharp/Services/IDataService.cs
+++ b/QuickBooksSharp/Services/IDataService.cs
@@ -1,6 +1,7 @@
 ﻿using QuickBooksSharp.Entities;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace QuickBooksSharp
@@ -14,5 +15,14 @@ namespace QuickBooksSharp
         Task<Report> GetReportAsync(string reportName, Dictionary<string, string> parameters);
         Task<IntuitResponse<TEntity>> PostAsync<TEntity>(TEntity e) where TEntity : IntuitEntity;
         Task<IntuitResponse<QueryResponse<TEntity>>> QueryAsync<TEntity>(string query) where TEntity : IntuitEntity;
+
+        /// <summary>
+        /// Get an invoice as PDF
+        /// <para>This resource returns the specified object in the response body as an Adobe Portable Document Format (PDF) file. The resulting PDF file is formatted according to custom form styles in the company settings.</para>
+        /// <see href="https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/invoice#get-an-invoice-as-pdf">QBO Documentation</see>
+        /// </summary>
+        /// <param name="invoiceId">Unique identifier for this object</param>
+        /// <returns>This resource returns the specified object in the response body as an Adobe Portable Document Format (PDF) file. The resulting PDF file is formatted according to custom form styles in the company settings.</returns>
+        Task<Stream> GetInvoicePDFAsync(string invoiceId);
     }
 }

--- a/README.md
+++ b/README.md
@@ -167,5 +167,12 @@ public async Task<IActionResult> Webhook()
         //return HTTP error status
 
     //Process webhook
+    WebhookEvent notification = JsonSerializer.Deserialize<WebhookEvent>(requestBodyJSON, QuickBooksHttpClient.JsonSerializerOptions);
 }
+```
+
+## Download Invoice PDF
+```csharp
+    var invoiceId = "1023";
+    var invoidePdfStream = await dataService.GetInvoicePDF(invoiceId);
 ```


### PR DESCRIPTION
- Used correct Async suffix convention by renaming GetInvoicePDF to GetInvoicePDFAsync
- Added GetInvoicePDFAsync method in IDataService interface
- Marked GetInvoicePDF as obsolete for backwards compatibility
- Added documentation in README