### PR TITLE
Adding Emailed into OperationEnum

### DIFF
--- a/QuickBooksSharp/Entities/Generated.cs
+++ b/QuickBooksSharp/Entities/Generated.cs
@@ -1631,6 +1631,7 @@ namespace QuickBooksSharp.Entities
         @void,
         send,
         merge,
+        emailed
     }
     public enum SyncType
     {


### PR DESCRIPTION
Adding Emailed into OperationEnum that it is used by the following entites:

- Estimate
- Invoice
- Payment
- SalesReceipt
- CreditMemo
- RefundReceipt
- PurchaseOrder