### PR TITLE
Switch .NET Standard 2.0

### DIFF
--- a/QuickBooksSharp/Authentication/AuthenticationService.cs
+++ b/QuickBooksSharp/Authentication/AuthenticationService.cs
@@ -24,7 +24,7 @@ namespace QuickBooksSharp
         {
             return new Url("https://appcenter.intuit.com/connect/oauth2")
                         .SetQueryParam("client_id", clientId)
-                        .SetQueryParam("scope", string.Join(' ', scopes))
+                        .SetQueryParam("scope", string.Join(" ", scopes))
                         .SetQueryParam("redirect_uri", redirectUrl)
                         .SetQueryParam("response_type", "code")
                         .SetQueryParam("state", state)

--- a/QuickBooksSharp/QuickBooksSharp.csproj
+++ b/QuickBooksSharp/QuickBooksSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net6.0;</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;</TargetFrameworks>
 		<Authors>Better Reports</Authors>
 		<Company>Better Reports</Company>
 		<Product></Product>
@@ -13,6 +13,7 @@
 		<Nullable>enable</Nullable>
 		<PackageTags>quickbooks online intuit qbo accounting</PackageTags>
 		<PackageReleaseNotes>DateOnly properties generated for .NET6+</PackageReleaseNotes>
+		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This allows it to be consumed from .Net Framework as well.
I also updated language version to latest explicitly, since targeting .net standard brings us down to version 7.3 which does not support NRTs.
 The update caused some overload resolution error which I also fixed.

Is there any reason why wouldn't update to .NET 8 since .NET 6 is EOL?